### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface HelloWorld : NSObject
+
+- (NSString *)hello:(NSString *)name;
+
+@end


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.


See https://github.com/exercism/meta/issues/89