### PR TITLE
Fix invalid exercise UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -480,7 +480,7 @@
         "integers"
       ],
       "unlocked_by": null,
-      "uuid": "f64b5655-0256-0580-a1dc-5b114910f0f36f0c255"
+      "uuid": "1d841c21-f251-42ff-9fbd-cc88330eb1c3"
     },
     {
       "core": false,
@@ -492,7 +492,7 @@
         "mathematics"
       ],
       "unlocked_by": null,
-      "uuid": "8e3d974c-0020-3880-e92e-af4fedd478e00ce788a"
+      "uuid": "924a7103-040c-4b49-a11d-16c9e811d84b"
     }
   ],
   "foregone": [],


### PR DESCRIPTION
The previous version of `configlet uuid` was known to generate invalid UUIDs. The latest release of Configlet [v3.6.1](https://github.com/exercism/configlet/releases) fixes that issue for newly added exercises, but existing exercise UUIDs need to be updated manually.

This change pertains to exercism/configlet#99