### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -64,7 +64,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -85,6 +86,7 @@
       "difficulty": 1,
       "topics": [
         "lists",
+        "math",
         "transforming"
       ]
     },
@@ -185,7 +187,8 @@
       "difficulty": 2,
       "topics": [
         "integers",
-        "looping"
+        "looping",
+        "math"
       ]
     },
     {
@@ -261,7 +264,8 @@
       "difficulty": 3,
       "topics": [
         "discriminated_unions",
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -295,7 +299,7 @@
       "difficulty": 3,
       "topics": [
         "filtering",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -306,7 +310,7 @@
       "difficulty": 3,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -408,6 +412,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
+        "math",
         "transforming"
       ]
     },
@@ -419,6 +424,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
+        "math",
         "strings",
         "transforming"
       ]
@@ -478,7 +484,7 @@
       "difficulty": 4,
       "topics": [
         "lists",
-        "mathematics",
+        "math",
         "recursion"
       ]
     },
@@ -573,7 +579,7 @@
       "topics": [
         "integers",
         "loops",
-        "mathematics"
+        "math"
       ]
     }
   ]


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110