### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Objective-C is a thin layer on top of C, and is a "strict superset" of C, meaning that it is possible to compile any C program with an Objective-C compiler, and to freely include C language code within an Objective-C class. 
 Objective-C derives its object syntax from Smalltalk. 
 All of the syntax for non-object-oriented operations (including primitive variables, pre-processing, expressions, function declarations, and function calls) is identical to that of C, while the syntax for object-oriented features is an implementation of Smalltalk-style messaging. 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,1 +1,3 @@
+# Installation
+
 Ensure that you have the latest Xcode installed through the Mac App Store.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Exercism will only download a test file. You will need to manually create the header and the source file associated with the exercise. You will need to generate an Xcode Project file with the test file, the header file (.h) and the source file (.m). Alternatively, you can use a test runner utility that's described below.
 
 ### Creating the project in Xcode

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -2,7 +2,7 @@
 
 Exercism will only download a test file. You will need to manually create the header and the source file associated with the exercise. You will need to generate an Xcode Project file with the test file, the header file (.h) and the source file (.m). Alternatively, you can use a test runner utility that's described below.
 
-### Creating the project in Xcode
+## Creating the project in Xcode
 
 * Start Xcode and create a new project.
 * Select OS X > Application and then Command Line Tool.
@@ -29,7 +29,7 @@ Tests will be run through Xcode.
 
 __Note:__ If you receive the error "No visible `@interface` for ExerciseName declares the selector ExerciseSelector," you followed the steps correctly, but haven't written anything in your header/implementation file(s). After you declare your method in the .h file and define it in the .m file, your tests should raise more helpful errors that will lead you towards completing the exercise. Read this [primer on Objective-C Classes](http://blog.teamtreehouse.com/beginners-guide-objective-c-classes-objects) for more in-depth information.
 
-### A Test Runner
+## A Test Runner
 
 An alternative to manually generating the project file is to use a test runner utility written in ruby, [`objc`](https://rubygems.org/gems/objc/), that will create a project file for you with the test file, header file and source file.
 

--- a/exercises/practice/bob/.meta/description.md
+++ b/exercises/practice/bob/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 
 Bob answers 'Sure.' if you ask him a question.


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
