### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,18 @@
+{
+  "docs": [
+    {
+      "uuid": "014402ed-4b07-4659-b007-55df6f834bc6",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Objective-C locally",
+      "blurb": "Learn how to install Objective-C locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "1ae7054b-ad70-4ceb-9fa1-84978a4171f4",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Objective-C track",
+      "blurb": "Learn how to test your Objective-C exercises on Exercism"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
