### PR TITLE
Delete Circle CI config file

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,0 @@
-machine:
-  xcode:
-    version: "8.2"
-test:
-  override:
-    - xcodebuild test -project 'xcodeProject/ObjectiveC.xcodeproj' -scheme 'xobjectivecTest' -sdk macosx10.12


### PR DESCRIPTION
The Circle CI job stopped working due to upstream changes. I've disabled the Circle CI build. This deletes the now-unused config file.